### PR TITLE
New content attention score function

### DIFF
--- a/layers/attention.py
+++ b/layers/attention.py
@@ -65,7 +65,8 @@ class Attention(nn.Module):
             score = torch.bmm(qw, kt)
             
         # base_a attention module: FwNN with 2 inputs
-        # W1 * tanh(W2 * memory representation + W3 * aspect representation + bias)                      
+        # W1 * tanh(W2 * memory representation + W3 * aspect representation + bias)  
+        # W2 == kx and W3 == qx??
         elif self.score_function == 'a':
             kxx = torch.unsqueeze(kx, dim=1).expand(-1, q_len, -1, -1)
             qxx = torch.unsqueeze(qx, dim=2).expand(-1, -1, k_len, -1)


### PR DESCRIPTION
Hello,

I implemented a new score function for the attention layer. This is score function is used in the paper I am replicating and the authors get good results with it. It uses a FwNN2 instead of the concatenation between aspect and memory.

$$ W1 * tanh(W2 * memory representation + W3 * aspect representation + bias)  $$
![baseline a cam](https://user-images.githubusercontent.com/36967362/40360514-ba16cb78-5dc6-11e8-97c2-32963277a625.PNG)

I am not getting the same results as the authours so I was wondering if you could verify if the implentation is correct?

Thanks in advance,
