### PR TITLE
Fix PyTorch version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.13.3
-torch>=0.4.0
+torch>=0.4.0,<=1.4.0
 transformers>=3.5.1,<4.0.0
 sklearn


### PR DESCRIPTION
The `train.py` code in the repo doesn't work with PyTorch higher than 1.4.0 due to API changes.
This PR fixes PyTorch to be in between 0.4.0 and 1.4.0 versions.